### PR TITLE
Remove hidden class

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -83,7 +83,7 @@
               color: red
             }
 
-            #styling-example vcf-breadcrumb:not([aria-current="page"]) .breadcrumb-anchor:not(.hidden):hover {
+            #styling-example vcf-breadcrumb:not([aria-current="page"]) .breadcrumb-anchor:hover {
               color: var(--lumo-primary-text-color);
               text-decoration: underline;
             }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "https://raw.githubusercontent.com/vaadin-component-factory/vcf-breadcrumb/master/LICENSE",
   "exports": {
     ".": "./dist/src/index.js",
-    "./vcf-breadcrumbs.js": "./dist/src/vcf-breadcrumbs.js"
+    "./dist/src/vcf-breadcrumbs.js": "./dist/src/vcf-breadcrumbs.js"
   },
   "files": [
     "vcf-*.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin-component-factory/vcf-breadcrumb",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Web Component providing an easy way to display breadcrumb.",
   "author": "Vaadin Ltd",  
   "type": "module",

--- a/src/component/vcf-breadcrumb.ts
+++ b/src/component/vcf-breadcrumb.ts
@@ -79,11 +79,7 @@ class VcfBreadcrumb extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))
         :host(:last-of-type) [part='separator'] {
           display: none;
         }        
-        
-        .hidden {
-          display: none;
-        }
-    
+
         :host {
           display: flex;
           align-items: center;
@@ -100,10 +96,6 @@ class VcfBreadcrumb extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))
       anchor.setAttribute("href", this.href);
     }
     anchor.classList.add("breadcrumb-anchor");
-    const linkClassName = this._getLinkClassName();
-    if(linkClassName) {
-      anchor.classList.add(linkClassName);
-    }      
     // Get anchor label from #pageLabel slot
     let labelSlot = this.shadowRoot?.querySelector("#pageLabel") as HTMLSlotElement;
     const labelText = labelSlot.assignedNodes({ flatten: true })[0];
@@ -125,12 +117,7 @@ class VcfBreadcrumb extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))
   _isEllipsisElement() {
     return this.getAttribute("part") === "ellipsis";
   }
-
-  _getLinkClassName() {
-    if (this.href === '') {
-      return 'hidden';
-    }
-  } 
+ 
 }
 
 export { VcfBreadcrumb };

--- a/src/component/vcf-breadcrumbs.ts
+++ b/src/component/vcf-breadcrumbs.ts
@@ -62,7 +62,7 @@ export class VcfBreadcrumbs extends ResizeMixin(ElementMixin(ThemableMixin(Polyl
   }
 
   static get version() {
-    return '2.0.0';
+    return '2.0.1';
   }
 
   static get styles() {


### PR DESCRIPTION
This PR includes a fix to remove a "hidden" class added to the anchors in the breadcrumb that is no needed.

Also it includes an update on the exports value to fix a problem with the imports in the server side implementation of the component.

Version was updated to 2.0.1