### PR TITLE
feat: show popover with hidden items on ellipsis element

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -32,7 +32,7 @@
           <vcf-breadcrumbs id="basic-example">
             <vcf-breadcrumb href="#">Home</vcf-breadcrumb>
             <vcf-breadcrumb href="#">Directory</vcf-breadcrumb>
-            <vcf-breadcrumb href="#">Components</vcf-breadcrumb>
+            <vcf-breadcrumb href="#" collapse>Components</vcf-breadcrumb>
             <vcf-breadcrumb href="#">VCF Components</vcf-breadcrumb>
             <vcf-breadcrumb>Breadcrumb</vcf-breadcrumb>
           </vcf-breadcrumbs>
@@ -42,22 +42,23 @@
       <demo-snippet>
         <template>
           <style>
-            #collapse-example vcf-breadcrumb .breadcrumb-anchor {
+            .collapse-example-class .breadcrumb-anchor, .collapse-example-class.hidden-breadcrumb-anchor {
               color: var(--lumo-primary-text-color);
               text-decoration: none;
             }
-            #collapse-example vcf-breadcrumb[aria-current="page"] .breadcrumb-anchor {
+
+            .collapse-example-class[aria-current="page"] .breadcrumb-anchor {
               color: var(--lumo-body-text-color);
-            }
+            }            
           </style>
           <vcf-breadcrumbs id="collapse-example">
-            <vcf-breadcrumb href="#">Home</vcf-breadcrumb>
-            <vcf-breadcrumb href="#" collapse>Directory</vcf-breadcrumb>
-            <vcf-breadcrumb href="#" collapse>Flow</vcf-breadcrumb>
-            <vcf-breadcrumb href="#" >Vaadin Latest</vcf-breadcrumb>
-            <vcf-breadcrumb href="#" collapse>Components</vcf-breadcrumb>
-            <vcf-breadcrumb href="#" collapse>VCF Components</vcf-breadcrumb>
-            <vcf-breadcrumb>Breadcrumb</vcf-breadcrumb>
+            <vcf-breadcrumb class="collapse-example-class" href="#">Home</vcf-breadcrumb>
+            <vcf-breadcrumb class="collapse-example-class" href="#" collapse>Directory</vcf-breadcrumb>
+            <vcf-breadcrumb class="collapse-example-class" href="#" collapse>Flow</vcf-breadcrumb>
+            <vcf-breadcrumb class="collapse-example-class" href="#" collapse>Vaadin Latest</vcf-breadcrumb>
+            <vcf-breadcrumb class="collapse-example-class" href="#" >Components</vcf-breadcrumb>
+            <vcf-breadcrumb class="collapse-example-class" href="#" collapse>VCF Components</vcf-breadcrumb>
+            <vcf-breadcrumb class="collapse-example-class">Breadcrumb</vcf-breadcrumb>
           </vcf-breadcrumbs>
         </template>
       </demo-snippet>
@@ -71,10 +72,12 @@
               --vcf-breadcrumb-separator-size: var(--lumo-font-size-l);
               color: var(--lumo-body-text-color);
             }
-            #styling-example vcf-breadcrumb .breadcrumb-anchor {
+
+            .styling-example-class .breadcrumb-anchor, .styling-example-class.hidden-breadcrumb-anchor  {
               color: var(--lumo-body-text-color);
               text-decoration: none;
             }
+
             #styling-example vcf-breadcrumb[aria-current="page"] .breadcrumb-anchor {
               color: var(--lumo-contrast-60pct);
             }
@@ -90,10 +93,10 @@
           </style>
           <vcf-breadcrumbs id="styling-example">
             <vcf-breadcrumb href="#" class="first">Home</vcf-breadcrumb>
-            <vcf-breadcrumb href="#">Directory</vcf-breadcrumb>
-            <vcf-breadcrumb href="#" collapse>Components</vcf-breadcrumb>
-            <vcf-breadcrumb href="#">VCF Components</vcf-breadcrumb>
-            <vcf-breadcrumb>Breadcrumb</vcf-breadcrumb>
+            <vcf-breadcrumb href="#" collapse class="styling-example-class">Directory</vcf-breadcrumb>
+            <vcf-breadcrumb href="#" collapse class="styling-example-class">Components</vcf-breadcrumb>
+            <vcf-breadcrumb href="#" class="styling-example-class">VCF Components</vcf-breadcrumb>
+            <vcf-breadcrumb class="styling-example-class">Breadcrumb</vcf-breadcrumb>
           </vcf-breadcrumbs>
         </template>
       </demo-snippet>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin-component-factory/vcf-breadcrumb",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Web Component providing an easy way to display breadcrumb.",
   "author": "Vaadin Ltd",  
   "type": "module",
@@ -43,8 +43,10 @@
   },
   "dependencies": {
     "@vaadin/component-base": "^24.5.8",
+    "@vaadin/popover": "^24.5.8",
     "@vaadin/vaadin-lumo-styles": "^24.5.8",
     "@vaadin/vaadin-themable-mixin": "^24.5.8",
+    "@vaadin/vertical-layout": "^24.5.8",
     "lit": "^3.0.0"
   },
   "devDependencies": {

--- a/src/component/vcf-breadcrumb.ts
+++ b/src/component/vcf-breadcrumb.ts
@@ -109,6 +109,18 @@ class VcfBreadcrumb extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))
       anchor.setAttribute("id", this.id);
       const popover = this.querySelector('vaadin-popover[for="' + this.id + '"]');
       if (popover) {
+        anchor.addEventListener("keydown", (event) => {
+          if (event.key === " " || event.key === "Space") {
+            event.preventDefault();
+             // @ts-ignore
+            popover.opened = !popover.opened;
+          }
+        });     
+        popover.addEventListener("opened-changed", (event) => {
+          if (!((event as CustomEvent).detail.value)) {
+            anchor.focus(); // Return focus to the ellipsis element
+          }
+        });      
         anchor.appendChild(popover);
       }      
       this.removeAttribute("id");

--- a/src/component/vcf-breadcrumb.ts
+++ b/src/component/vcf-breadcrumb.ts
@@ -61,7 +61,7 @@ class VcfBreadcrumb extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))
   }
 
   static get version() {
-    return '2.0.1';
+    return '2.1.0';
   }
 
   render() {
@@ -84,7 +84,7 @@ class VcfBreadcrumb extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))
           display: flex;
           align-items: center;
           min-width: 40px;
-        }
+        }       
     `];
   }
 
@@ -100,6 +100,19 @@ class VcfBreadcrumb extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))
     let labelSlot = this.shadowRoot?.querySelector("#pageLabel") as HTMLSlotElement;
     const labelText = labelSlot.assignedNodes({ flatten: true })[0];
     anchor.appendChild(labelText);
+
+    // Add popover for ellipsis mode
+    if (this._isEllipsisElement()) {
+      // Add tabindex="0" to make it keyboard-accessible
+      anchor.setAttribute("tabindex", "0");
+      anchor.style.cursor = "pointer";
+      anchor.setAttribute("id", this.id);
+      const popover = this.querySelector('vaadin-popover[for="' + this.id + '"]');
+      if (popover) {
+        anchor.appendChild(popover);
+      }      
+      this.removeAttribute("id");
+    }
 
     this.appendChild(anchor);
   }

--- a/src/component/vcf-breadcrumbs.ts
+++ b/src/component/vcf-breadcrumbs.ts
@@ -230,7 +230,6 @@ export class VcfBreadcrumbs extends ResizeMixin(ElementMixin(ThemableMixin(Polyl
           item.textContent = element.textContent;
           item.setAttribute("href", element.getAttribute('href') ?? '');
           item.setAttribute("role", "menuitem");
-          item.classList.add();
           // Copy element class list
           const elementClasses = Array.from(element.classList);
           item.classList.add(...elementClasses);


### PR DESCRIPTION
When space is not enough to display all breadcrumbs that have the "collapse" attribute, they are hidden and a "ellipsis" element is shown instead. This PR addresses new feature to show the hidden breadcrumbs in a popover component attached to each "ellipsis" element.

As this is a new feature, version was updated to 2.1.0.