### PR TITLE
Fixes focus ring clipping

### DIFF
--- a/src/theme/lumo/vcf-breadcrumb-styles.ts
+++ b/src/theme/lumo/vcf-breadcrumb-styles.ts
@@ -42,5 +42,15 @@ registerStyles(
       white-space: nowrap;
       text-overflow: ellipsis;
     }
+
+    /* Focus ring */
+    :host(:focus-within) [part="link"] {
+      outline: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct)) auto 1px;
+      outline-offset: 1px;
+    }
+
+    ::slotted(a:focus) {
+      outline: none;
+    }
   `
 );


### PR DESCRIPTION
The focus ring is currently clipping as seen here:
<img width="566" alt="Image" src="https://github.com/user-attachments/assets/6c354820-f729-4d51-b855-16dd9205422b" />

This can be avoided by showing the focus ring on vcf-breadcrumb::part(link) instead of the anchor element.
<img width="560" alt="image" src="https://github.com/user-attachments/assets/a4fbde43-39d0-444d-be92-9d2fbd0ea170" />
