### PR TITLE
feat: add mobile mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ By default, there are few css variables that help you update the separator's sty
 | --vcf-breadcrumb-separator-margin | Margin of the separator icon | 0 |    
 | --vcf-breadcrumb-separator-padding | Padding of the separator icon | 0 var(--lumo-space-xs) |    
 
+## Updates since version 2.2.0
+
+Added support for [Mobile Mode](https://github.com/vaadin-component-factory/vcf-breadcrumb/issues/6). It can be triggered in two ways:
+- Based on a fixed breakpoint (same as other Vaadin components): `(max-width: 450px), (max-height: 450px)` or
+- Programmatically, using the flag `forceMobileMode`, which allows to enable mobile layout manually
+
+When in Mobile Mode, Breadcrumbs are styled for mobile navigation showing only back path.
+- Shows the last breadcrumb unless it's the current one
+- Shows the breadcrumb directly before the current one
+
+By default, mobile mode shows a back icon that can be customized using the CSS variable: `--vcf-breadcrumb-mobile-back-symbol`
+
 ## Running demo
 
 1. Fork the `vcf-breadcrumb` repository and clone it locally.

--- a/demo/index.html
+++ b/demo/index.html
@@ -100,6 +100,24 @@
           </vcf-breadcrumbs>
         </template>
       </demo-snippet>
+      <h3>Enabling mobile mode by flag Demo Sample</h3>
+      <demo-snippet>
+        <template>
+          <style>
+            #mobile-mode-flag-example .breadcrumb-anchor {
+              color: var(--lumo-primary-text-color);
+              text-decoration: none;
+            }  
+          </style>
+          <vcf-breadcrumbs id="mobile-mode-flag-example" force-mobile-mode>
+            <vcf-breadcrumb href="#">Home</vcf-breadcrumb>
+            <vcf-breadcrumb href="#">Directory</vcf-breadcrumb>
+            <vcf-breadcrumb href="#" collapse>Components</vcf-breadcrumb>
+            <vcf-breadcrumb href="#">VCF Components</vcf-breadcrumb>
+            <vcf-breadcrumb>Breadcrumb</vcf-breadcrumb>
+          </vcf-breadcrumbs>
+        </template>
+      </demo-snippet>
      </main>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin-component-factory/vcf-breadcrumb",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Web Component providing an easy way to display breadcrumb.",
   "author": "Vaadin Ltd",  
   "type": "module",
@@ -96,6 +96,12 @@
         "always",
         {
           "ignorePackages": true
+        }
+      ],
+      "sort-imports": [
+        "error",
+        { 
+          "ignoreDeclarationSort": true 
         }
       ]
     }

--- a/src/component/vcf-breadcrumb.ts
+++ b/src/component/vcf-breadcrumb.ts
@@ -61,7 +61,7 @@ class VcfBreadcrumb extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))
   }
 
   static get version() {
-    return '2.1.1';
+    return '2.2.0';
   }
 
   render() {

--- a/src/theme/lumo/vcf-breadcrumb-styles.ts
+++ b/src/theme/lumo/vcf-breadcrumb-styles.ts
@@ -18,6 +18,7 @@ registerStyles(
       --vcf-breadcrumb-separator-size: var(--lumo-font-size-s);
       --vcf-breadcrumb-separator-margin: 0;
       --vcf-breadcrumb-separator-padding: 0 var(--lumo-space-xs);
+      --vcf-breadcrumb-mobile-back-symbol: var(--lumo-icons-angle-left);
     }
 
     :host {
@@ -51,6 +52,20 @@ registerStyles(
 
     ::slotted(a:focus) {
       outline: none;
+    }
+
+    /* mobile back mode */
+    :host(.mobile-back) {
+      display: none;
+    }
+
+    :host(.mobile-back) [part='separator'] {
+      display: none;
+    }
+
+    :host(.mobile-back.is-last-not-current),
+    :host(.mobile-back.is-before-current) {
+      display: inline-block;
     }
   `
 );


### PR DESCRIPTION
The PR includes implementation of new requested feature **mobile mode** which can be triggered in two ways:
 - A fixed breakpoint (same as other Vaadin components):  `(max-width: 450px), (max-height: 450px)`
 - Programmatically by using the flag `forceMobileMode`, which allows to enable mobile layout manually

On mobile mode (either responsive or forced) the component will now be styled for mobile navigation by showing immediate parent breadcrumb and an icon representing "navigation back".

Component version was updated to 2.2.0.

Close #6